### PR TITLE
Fix groupby commands not running in build environment

### DIFF
--- a/textbook/07/3/Groups.ipynb
+++ b/textbook/07/3/Groups.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "57db6778",
    "metadata": {
     "tags": [
@@ -42,7 +42,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 2,
    "id": "ad682f10",
    "metadata": {},
    "outputs": [],
@@ -62,7 +62,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "id": "b75f32fb",
    "metadata": {},
    "outputs": [
@@ -166,7 +166,7 @@
        "6      Sausage Burrito     300.0     12.0   2.10     Breakfast"
       ]
      },
-     "execution_count": 2,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -190,7 +190,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "8fed12e2",
    "metadata": {},
    "outputs": [
@@ -249,7 +249,7 @@
        "6  Sausage Burrito     300.0     12.0   2.10  Breakfast"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -282,7 +282,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "id": "81ac5901",
    "metadata": {},
    "outputs": [
@@ -339,13 +339,13 @@
        "Lunch/Dinner  3.015"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "full_menu.groupby('Category').mean()[['Price']]"
+    "full_menu.groupby('Category')[['Price']].mean()"
    ]
   },
   {
@@ -378,7 +378,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 6,
    "id": "a00235d1",
    "metadata": {},
    "outputs": [
@@ -435,13 +435,13 @@
        "Lunch/Dinner     4"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "full_menu.groupby('Category').count()[['Item']]"
+    "full_menu.groupby('Category')[['Item']].count()"
    ]
   },
   {
@@ -454,7 +454,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 7,
    "id": "d699e56d",
    "metadata": {},
    "outputs": [
@@ -511,13 +511,13 @@
        "Lunch/Dinner  12.06"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "full_menu.groupby('Category').sum()[['Price']]"
+    "full_menu.groupby('Category')[['Price']].sum()"
    ]
   },
   {
@@ -547,7 +547,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 8,
    "id": "34db8325",
    "metadata": {},
    "outputs": [
@@ -661,15 +661,15 @@
        "</div>"
       ],
       "text/plain": [
-       "  work_year experience_level employment_type                  job_title   \n",
-       "0     2021e               EN              FT    Data Science Consultant  \\\n",
+       "  work_year experience_level employment_type                  job_title  \\\n",
+       "0     2021e               EN              FT    Data Science Consultant   \n",
        "1      2020               SE              FT             Data Scientist   \n",
        "2     2021e               EX              FT       Head of Data Science   \n",
        "3     2021e               EX              FT               Head of Data   \n",
        "4     2021e               EN              FT  Machine Learning Engineer   \n",
        "\n",
-       "   salary salary_currency  salary_in_usd employee_residence  remote_ratio   \n",
-       "0   54000             EUR          64369                 DE            50  \\\n",
+       "   salary salary_currency  salary_in_usd employee_residence  remote_ratio  \\\n",
+       "0   54000             EUR          64369                 DE            50   \n",
        "1   60000             EUR          68428                 GR           100   \n",
        "2   85000             USD          85000                 RU             0   \n",
        "3  230000             USD         230000                 RU            50   \n",
@@ -683,7 +683,7 @@
        "4               US            S  "
       ]
      },
-     "execution_count": 10,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -706,7 +706,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "bb40213d",
    "metadata": {},
    "outputs": [
@@ -820,15 +820,15 @@
        "</div>"
       ],
       "text/plain": [
-       "   work_year experience_level employment_type                  job_title   \n",
-       "0      2021e               EN              FT    Data Science Consultant  \\\n",
+       "   work_year experience_level employment_type                  job_title  \\\n",
+       "0      2021e               EN              FT    Data Science Consultant   \n",
        "4      2021e               EN              FT  Machine Learning Engineer   \n",
        "11     2021e               EN              FT             Data Scientist   \n",
        "17     2021e               EN              FT               Data Analyst   \n",
        "18     2021e               EN              FT               Data Analyst   \n",
        "\n",
-       "    salary salary_currency  salary_in_usd employee_residence  remote_ratio   \n",
-       "0    54000             EUR          64369                 DE            50  \\\n",
+       "    salary salary_currency  salary_in_usd employee_residence  remote_ratio  \\\n",
+       "0    54000             EUR          64369                 DE            50   \n",
        "4   125000             USD         125000                 US           100   \n",
        "11   13400             USD          13400                 UA           100   \n",
        "17   90000             USD          90000                 US           100   \n",
@@ -842,7 +842,7 @@
        "18               US            S  "
       ]
      },
-     "execution_count": 8,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -863,7 +863,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 10,
    "id": "47b28d0a",
    "metadata": {},
    "outputs": [
@@ -1128,7 +1128,7 @@
        "                MI                             IN            M  "
       ]
      },
-     "execution_count": 14,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1151,7 +1151,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 11,
    "id": "e4c45e06",
    "metadata": {},
    "outputs": [
@@ -1166,7 +1166,7 @@
        "Name: salary_in_usd, dtype: float64"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1189,7 +1189,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 12,
    "id": "fa86ce17",
    "metadata": {},
    "outputs": [
@@ -1246,7 +1246,7 @@
        "S                 58"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1267,7 +1267,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 13,
    "id": "db7007a0",
    "metadata": {},
    "outputs": [
@@ -1547,7 +1547,7 @@
        "                 S                          US  "
       ]
      },
-     "execution_count": 19,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1568,7 +1568,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 14,
    "id": "3ba98f68",
    "metadata": {},
    "outputs": [
@@ -1591,7 +1591,7 @@
        "Name: salary_in_usd, dtype: float64"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1612,7 +1612,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 15,
    "id": "a44ea4c6",
    "metadata": {},
    "outputs": [
@@ -1686,7 +1686,7 @@
        "SE                134465.604651  122572.125000  120978.055556"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1720,7 +1720,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12"
+   "version": "3.11.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
In the build environment

     sys.version, sys.version_info
    ('3.11.5 | packaged by conda-forge | (main, Aug 27 2023, 03:34:09) [GCC 12.3.0]', 
    sys.version_info(major=3, minor=11, micro=5, releaselevel='final', serial=0))

notebook 07/3 has some errors evaluating groupby() statements.  

This seems to address these problems for me.

